### PR TITLE
Change Goozma's drill dash rotation

### DIFF
--- a/Content/NPCs/Bosses/GoozmaBoss/Goozma.Drawing.cs
+++ b/Content/NPCs/Bosses/GoozmaBoss/Goozma.Drawing.cs
@@ -246,6 +246,9 @@ public partial class Goozma : ModNPC
 
             float tentaCount = 5;
             int segmentCount = 12;
+            float tentacleRotationSwerve = NPC.velocity.Length() * 0.001f;
+            float tentacleWobbleFactor = 1f + tentacleRotationSwerve * 24f;
+
             for (int j = 0; j < tentaCount; j++) {
                 float rot = 0.2f - (j / tentaCount) * 0.5f + MathHelper.PiOver2 - tilt * 0.2f;
                 Vector2 pos = basePos + new Vector2(0, 20).RotatedBy(MathHelper.Lerp(0.5f, -1.3f, j / tentaCount));
@@ -265,8 +268,8 @@ public partial class Goozma : ModNPC
                     }
 
                     float tentacleLerp = Utils.GetLerpValue(tentaCount * 0.5f, tentaCount, j - Math.Abs(tentacleVel.X) * 0.001f * (1f - prog)) * (i / (float)segments);
-                    float newRot = Math.Clamp(tentacleVel.X * 0.01f, -1, 1) * prog - Math.Clamp(tentacleVel.Y * 0.015f, -0.6f, 1f) * tentacleLerp;
-                    float tentacleWobble = (float)Math.Sin((NPC.localAI[0] * 0.06f - prog * freq - (j / tentaCount) * 0.5f) % MathHelper.TwoPi) * (0.66f - tentacleVel.Length() * 0.1f);
+                    float newRot = Math.Clamp(tentacleVel.X * 0.01f, -1, 1) * prog - Math.Clamp(tentacleVel.Y * 0.015f, -0.6f, 1f) * tentacleLerp - i * (extraTentacleSwerve + tentacleRotationSwerve);
+                    float tentacleWobble = (float)Math.Sin((NPC.localAI[0] * 0.06f - prog * freq - (j / tentaCount) * 0.5f) % MathHelper.TwoPi) * (0.66f - tentacleVel.Length() * 0.1f) * tentacleWobbleFactor;
                     Vector2 nextStick = stick.RotatedBy(newRot + tentacleWobble * tentacleLerp);
                     Vector2 stretch = new Vector2(0.6f + prog * 0.7f, lastPos.Distance(lastPos + nextStick) / (frame.Height - 4)) * MathHelper.Lerp(headScale, 1f, i / (float)segments);
                     if (i == 0 || i >= segments - 1) {

--- a/Content/NPCs/Bosses/GoozmaBoss/Goozma.cs
+++ b/Content/NPCs/Bosses/GoozmaBoss/Goozma.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using CalamityHunt.Common.DropRules;
 using CalamityHunt.Common.GlobalNPCs;
 using CalamityHunt.Common.Graphics;
@@ -47,7 +46,6 @@ using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.Utilities;
 using static CalamityHunt.Common.Systems.ConditionalValue;
-using static tModPorter.ProgressUpdate;
 
 namespace CalamityHunt.Content.NPCs.Bosses.GoozmaBoss;
 
@@ -170,7 +168,7 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
     public override void ModifyNPCLoot(NPCLoot npcLoot)
     {
         npcLoot.Add(ItemDropRule.ByCondition(new GoozmaSoulDropRule(), ModContent.ItemType<GoozmaSoul>()));
-        
+
         if (ModLoader.HasMod(HUtils.CalamityMod)) {
             npcLoot.Add(ItemDropRule.ByCondition(new GoozmaDownedDropRule(), ModContent.ItemType<GoozmaLore>()));
         }
@@ -400,11 +398,13 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
 
     private bool initializedDeathRoar = false;
 
+    private int drillDashDriftDirection;
     private int drillDashCounter13 = 0;
     private bool fusionRayFlag = false;
 
     public override void AI()
     {
+        extraTentacleSwerve *= 0.94f;
 
         if (Phase == -1 && Time <= 0) {
 
@@ -1092,6 +1092,7 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
 
                                 if (Time % dashTime > 25 && Time % dashTime < 74) {
 
+                                    drillDashDriftDirection = Math.Sign(NPC.velocity.X);
 
                                     //if (Main.netMode != NetmodeID.MultiplayerClient) {
                                     rotate = true;
@@ -1132,6 +1133,15 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
                                 else {
                                     //if (Main.netMode != NetmodeID.MultiplayerClient) {
                                     NPC.velocity *= 0.7f;
+
+                                    // Spin in the direction that Goozma was originally going during his dash until he loses his angular momentum.
+                                    float rotationHorizontality = MathF.Cos(NPC.rotation);
+                                    if (rotationHorizontality < 0.97f) {
+                                        float rotationSlowdown = Utils.GetLerpValue(0.97f, 0.45f, rotationHorizontality, true);
+                                        NPC.rotation += drillDashDriftDirection * rotationSlowdown * 0.22f;
+                                        extraTentacleSwerve = MathHelper.Lerp(extraTentacleSwerve, drillDashDriftDirection * rotationSlowdown * -0.22f, 0.16f);
+                                        rotate = true;
+                                    }
                                     //}
                                 }
 
@@ -1514,7 +1524,7 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
             case -23:
                 // eat astrageldon
                 Mod catalyst = ModLoader.GetMod(HUtils.CatalystMod);
- 
+
                 Attack = (int)AttackList.DevouringTheInnocent;
 
                 NPC.dontTakeDamage = true;
@@ -1557,7 +1567,7 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
                         NPC.active = false;
                     }
                 }
-                
+
                 break;
             default:
 
@@ -2008,17 +2018,17 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
 
                     float angle = MathHelper.SmoothStep(1.5f, 0.9f, Time / 350f);
                     if (Time % 6 == 0) {
-                         
+
                         if (Main.netMode != NetmodeID.MultiplayerClient) Projectile.NewProjectileDirect(NPC.GetSource_FromAI(), NPC.Center, Vector2.UnitY.RotatedBy(angle).RotatedByRandom(0.3f) * Main.rand.Next(4, 7), ModContent.ProjectileType<SlimeShot>(), GetDamage(1), 0);
                         if (Main.netMode != NetmodeID.MultiplayerClient) Projectile.NewProjectileDirect(NPC.GetSource_FromAI(), NPC.Center, Vector2.UnitY.RotatedBy(-angle).RotatedByRandom(0.3f) * Main.rand.Next(4, 7), ModContent.ProjectileType<SlimeShot>(), GetDamage(1), 0);
                     }
                     if ((Time + 6) % 6 == 0) {
-                         
+
                         if (Main.netMode != NetmodeID.MultiplayerClient) Projectile.NewProjectileDirect(NPC.GetSource_FromAI(), NPC.Center, Vector2.UnitY.RotatedBy(angle + 0.3f).RotatedByRandom(0.3f) * Main.rand.Next(2, 4), ModContent.ProjectileType<SlimeShot>(), GetDamage(1), 0);
                         if (Main.netMode != NetmodeID.MultiplayerClient) Projectile.NewProjectileDirect(NPC.GetSource_FromAI(), NPC.Center, Vector2.UnitY.RotatedBy(-angle - 0.3f).RotatedByRandom(0.3f) * Main.rand.Next(2, 4), ModContent.ProjectileType<SlimeShot>(), GetDamage(1), 0);
                     }
                     if (Target.Center.Y < NPC.Top.Y - 300) {
-                         
+
                         if (Main.netMode != NetmodeID.MultiplayerClient) Projectile.NewProjectileDirect(NPC.GetSource_FromAI(), NPC.Center, NPC.DirectionTo(Target.Center).SafeNormalize(Vector2.Zero) * Main.rand.Next(2, 8), ModContent.ProjectileType<SlimeShot>(), GetDamage(1), 0);
                     }
                 }
@@ -2241,7 +2251,7 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
 
                 if (Phase == -2) {
                     if (Time >= 2 && !fusionRayFlag) {
-                         
+
                         if (Main.netMode != NetmodeID.MultiplayerClient) {
                             Projectile fusionRay = Projectile.NewProjectileDirect(NPC.GetSource_FromAI(), NPC.Center, NPC.DirectionTo(Target.Center).SafeNormalize(Vector2.Zero), ModContent.ProjectileType<FusionRay>(), GetDamage(7), 0,
                                                                          ai0: 200,
@@ -2299,7 +2309,7 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
                     if (Time > 500) {
                         if (Time % 70 == 0) {
                             SoundEngine.PlaySound(bloatSound, NPC.Center);
-                             
+
                             if (Main.netMode != NetmodeID.MultiplayerClient) Projectile.NewProjectileDirect(NPC.GetSource_FromAI(), NPC.Center, NPC.DirectionTo(targetPos).SafeNormalize(Vector2.Zero) * 5, ModContent.ProjectileType<BloatedBlast>(), GetDamage(5), 0);
                         }
 
@@ -2353,11 +2363,12 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
     private float extraTilt;
     private Vector2 drawOffset;
     private float headScale;
+    private float extraTentacleSwerve;
     public Vector2 drawVelocity;
     private Vector2 tentacleVelocity;
     private Vector2 tentacleAcceleration;
     private Vector2[] oldVel;
-    public bool rotate;
+    public bool rotate; // TODO -- Really opaque name. Consider renaming to ManuallyRotating or something maybe?
 
     public override void FindFrame(int frameHeight)
     {

--- a/Content/NPCs/Bosses/GoozmaBoss/Goozma.cs
+++ b/Content/NPCs/Bosses/GoozmaBoss/Goozma.cs
@@ -1139,9 +1139,10 @@ public partial class Goozma : ModNPC, ISubjectOfNPC<Goozma>
                                     if (rotationHorizontality < 0.97f) {
                                         float rotationSlowdown = Utils.GetLerpValue(0.97f, 0.45f, rotationHorizontality, true);
                                         NPC.rotation += drillDashDriftDirection * rotationSlowdown * 0.22f;
-                                        extraTentacleSwerve = MathHelper.Lerp(extraTentacleSwerve, drillDashDriftDirection * rotationSlowdown * -0.22f, 0.16f);
+                                        extraTentacleSwerve = MathHelper.Lerp(extraTentacleSwerve, rotationSlowdown * -0.22f, 0.16f);
                                         rotate = true;
                                     }
+                                    NPC.direction = drillDashDriftDirection;
                                     //}
                                 }
 


### PR DESCRIPTION
Makes Goozma do a roll after his drill dashes, rather than just AngleLerp-ing his way downward again and effectively awkwardly cancelling the momentum he received from his dash.